### PR TITLE
Add basic ExamLock client and server skeleton

### DIFF
--- a/ExamLock.Client/ExamLock.Client.csproj
+++ b/ExamLock.Client/ExamLock.Client.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/ExamLock.Client/Program.cs
+++ b/ExamLock.Client/Program.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+class Program
+{
+    static async Task Main()
+    {
+        var http = new HttpClient();
+        http.BaseAddress = new Uri("http://localhost:5000");
+
+        string hwid = HardwareId.Get();
+        Console.WriteLine($"HWID: {hwid}");
+
+        while (true)
+        {
+            Console.Write("Username: ");
+            string username = Console.ReadLine() ?? "";
+            Console.Write("Password: ");
+            string password = ReadPassword();
+
+            var loginReq = new { Hwid = hwid, Username = username, Password = password };
+            var resp = await http.PostAsync("/login", JsonContent(loginReq));
+            if (resp.IsSuccessStatusCode)
+            {
+                Console.WriteLine("Login successful.");
+                break;
+            }
+            var text = await resp.Content.ReadAsStringAsync();
+            if (text.Contains("Device not registered"))
+            {
+                Console.Write("Device not registered. Enter admin key: ");
+                string adminKey = Console.ReadLine() ?? "";
+                var regReq = new { Hwid = hwid, AdminKey = adminKey };
+                var regResp = await http.PostAsync("/register", JsonContent(regReq));
+                if (regResp.IsSuccessStatusCode)
+                {
+                    Console.WriteLine("Device registered. Try logging in again.");
+                }
+                else
+                {
+                    Console.WriteLine("Registration failed.");
+                }
+            }
+            else
+            {
+                Console.WriteLine("Login failed.");
+            }
+        }
+
+        var questionsResp = await http.GetAsync("/questions");
+        var questionsJson = await questionsResp.Content.ReadAsStringAsync();
+        var questions = JsonSerializer.Deserialize<string[]>(questionsJson) ?? Array.Empty<string>();
+        var answers = new string[questions.Length];
+
+        var start = DateTime.UtcNow;
+        var minDuration = TimeSpan.FromHours(1);
+        var maxDuration = TimeSpan.FromHours(4);
+
+        for (int i = 0; i < questions.Length; i++)
+        {
+            Console.WriteLine($"Question {i + 1}: {questions[i]}");
+            Console.Write("Answer: ");
+            answers[i] = Console.ReadLine() ?? "";
+        }
+
+        while ((DateTime.UtcNow - start) < minDuration)
+        {
+            Console.WriteLine("Minimum exam time not reached. Please wait...");
+            await Task.Delay(5000);
+        }
+
+        Console.WriteLine("Exam finished. Answers submitted.");
+        // In a real implementation, submit answers to server and log events.
+    }
+
+    static HttpContent JsonContent(object obj) =>
+        new StringContent(JsonSerializer.Serialize(obj), Encoding.UTF8, "application/json");
+
+    static string ReadPassword()
+    {
+        var password = new StringBuilder();
+        ConsoleKeyInfo key;
+        while ((key = Console.ReadKey(true)).Key != ConsoleKey.Enter)
+        {
+            if (key.Key == ConsoleKey.Backspace && password.Length > 0)
+            {
+                password.Remove(password.Length - 1, 1);
+                Console.Write("\b \b");
+            }
+            else
+            {
+                password.Append(key.KeyChar);
+                Console.Write("*");
+            }
+        }
+        Console.WriteLine();
+        return password.ToString();
+    }
+}
+
+static class HardwareId
+{
+    public static string Get()
+    {
+        return Environment.MachineName; // Placeholder for real hardware ID
+    }
+}

--- a/ExamLock.Server/ExamLock.Server.csproj
+++ b/ExamLock.Server/ExamLock.Server.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/ExamLock.Server/Program.cs
+++ b/ExamLock.Server/Program.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using System.Collections.Concurrent;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+var allowedDevices = new ConcurrentDictionary<string, bool>();
+var users = new ConcurrentDictionary<string, string>();
+users["student1"] = "password";
+
+var adminKeys = new ConcurrentDictionary<string, bool>();
+adminKeys["123456789"] = true; // example one-time key
+
+var logs = new ConcurrentDictionary<string, List<string>>();
+
+app.MapPost("/register", (DeviceRegistration reg) =>
+{
+    if (allowedDevices.ContainsKey(reg.Hwid))
+    {
+        return Results.BadRequest("Device already registered.");
+    }
+    if (!adminKeys.TryRemove(reg.AdminKey, out _))
+    {
+        return Results.BadRequest("Invalid admin key.");
+    }
+    allowedDevices[reg.Hwid] = true;
+    return Results.Ok();
+});
+
+app.MapPost("/login", (LoginRequest login) =>
+{
+    if (!allowedDevices.ContainsKey(login.Hwid))
+    {
+        return Results.BadRequest("Device not registered.");
+    }
+    if (users.TryGetValue(login.Username, out var pass) && pass == login.Password)
+    {
+        return Results.Ok(new { Token = Guid.NewGuid().ToString() });
+    }
+    return Results.Unauthorized();
+});
+
+app.MapGet("/questions", () =>
+{
+    var questions = new[]
+    {
+        "What is 2+2?",
+        "What is the capital of France?"
+    };
+    return Results.Ok(questions);
+});
+
+app.MapPost("/log", (LogEntry entry) =>
+{
+    var userLogs = logs.GetOrAdd(entry.Username, _ => new List<string>());
+    userLogs.Add($"{DateTime.UtcNow:o} - {entry.Message}");
+    return Results.Ok();
+});
+
+app.Run("http://0.0.0.0:5000");
+
+record DeviceRegistration(string Hwid, string AdminKey);
+record LoginRequest(string Hwid, string Username, string Password);
+record LogEntry(string Username, string Message);

--- a/ExamLock.sln
+++ b/ExamLock.sln
@@ -1,0 +1,22 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExamLock.Server", "ExamLock.Server\\ExamLock.Server.csproj", "{fc0ec060-7c34-47a9-ae5e-613f1a1b5bcc}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExamLock.Client", "ExamLock.Client\\ExamLock.Client.csproj", "{41cf3818-ed85-4ab2-b960-f7b17cfa06d1}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {fc0ec060-7c34-47a9-ae5e-613f1a1b5bcc}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {fc0ec060-7c34-47a9-ae5e-613f1a1b5bcc}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {fc0ec060-7c34-47a9-ae5e-613f1a1b5bcc}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {fc0ec060-7c34-47a9-ae5e-613f1a1b5bcc}.Release|Any CPU.Build.0 = Release|Any CPU
+        {41cf3818-ed85-4ab2-b960-f7b17cfa06d1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {41cf3818-ed85-4ab2-b960-f7b17cfa06d1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {41cf3818-ed85-4ab2-b960-f7b17cfa06d1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {41cf3818-ed85-4ab2-b960-f7b17cfa06d1}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- Add ASP.NET Core minimal API server for device registration, login, question retrieval, and logging
- Add console client that registers devices with admin key, logs in, retrieves questions, and enforces exam timing

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf0dddf388320b2fa2dda19d702bd